### PR TITLE
Message warning if Python version is not 3.6+

### DIFF
--- a/efficient_apriori/__init__.py
+++ b/efficient_apriori/__init__.py
@@ -4,8 +4,9 @@
 Implementation of the Apriori algorithm.
 """
 
-__version__ = '0.4.5'
+__version__ = "0.4.5"
 
+import sys
 from efficient_apriori.apriori import apriori
 from efficient_apriori.itemsets import itemsets_from_transactions
 from efficient_apriori.rules import Rule, generate_rules_apriori
@@ -23,5 +24,10 @@ def run_tests():
     """
     import pytest
     import os
+
     base, _ = os.path.split(__file__)
-    pytest.main(args=[base, '--doctest-modules'])
+    pytest.main(args=[base, "--doctest-modules"])
+
+
+if (sys.version_info[0] < 3) or (sys.version_info[1] < 6):
+    raise Exception("The `efficient_apriori` package only works for Python 3.6+.")

--- a/efficient_apriori/__init__.py
+++ b/efficient_apriori/__init__.py
@@ -30,4 +30,5 @@ def run_tests():
 
 
 if (sys.version_info[0] < 3) or (sys.version_info[1] < 6):
-    raise Exception("The `efficient_apriori` package only works for Python 3.6+.")
+    msg = "The `efficient_apriori` package only works for Python 3.6+."
+    raise Exception(msg)

--- a/efficient_apriori/itemsets.py
+++ b/efficient_apriori/itemsets.py
@@ -239,7 +239,7 @@ def itemsets_from_transactions(transactions: typing.Union[typing.List[tuple],
         print('  Found {} candidate itemsets of length 1.'.format(num_cand))
         print('  Found {} large itemsets of length 1.'.format(num_itemsets))
     if verbosity > 1:
-            print('    {}'.format(list((i,) for (i, c) in large_itemsets)))
+        print('    {}'.format(list((i,) for (i, c) in large_itemsets)))
 
     # If large itemsets were found, convert to dictionary
     if large_itemsets:


### PR DESCRIPTION
Confusingly, Python 3.5 will raise a KeyError, see #4 .

This PR adds an explicit exception if the Python version is not 3.6+. Better to fail with a good message.