### PR TITLE
Add support for itemset member tracking when input transactions contain IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,23 @@ def data_generator(filename):
 transactions = data_generator('dataset.csv')
 itemsets, rules = apriori(transactions, min_support=0.9, min_confidence=0.6)
 ```
+
+### Transactions with IDs
+
+If your transactions have IDs and you would like the results to show which 
+had frequent itemsets, you can convert your transactions to `TransactionWithId` 
+objects. This will return itemsets as `ItemsetCount`s which have a `members` 
+property which is the set of ids of frequent transactions.   
+
+```python
+from efficient_apriori import apriori
+from efficient_apriori.itemsets import TransactionWithId
+transactions = [
+    TransactionWithId(('eggs', 'bacon', 'soup'), '1'),
+    TransactionWithId(('eggs', 'bacon', 'apple'), '2'),
+    TransactionWithId(('soup', 'bacon', 'banana'), '3'),
+]
+itemsets, rules = apriori(transactions, min_support=0.2,  min_confidence=1)
+print(itemsets)
+# {1: {('bacon',): ItemsetCount(itemset_count=3, members={'1', '2', '3'}), ...
+```

--- a/README.md
+++ b/README.md
@@ -83,20 +83,19 @@ itemsets, rules = apriori(transactions, min_support=0.9, min_confidence=0.6)
 
 ### Transactions with IDs
 
-If your transactions have IDs and you would like the results to show which 
-had frequent itemsets, you can convert your transactions to `TransactionWithId` 
-objects. This will return itemsets as `ItemsetCount`s which have a `members` 
-property which is the set of ids of frequent transactions.   
+If you need to know which transactions occurred in the frequent itemsets,
+set the `output_transaction_ids` parameter to `True`.
+This changes the output to contain `ItemsetCount` objects for each itemset have 
+a `members` property which is the set of ids of frequent transactions as well 
+as a `count` property. The ids are the enumeration of the transactions in the
+order they appear.    
 
 ```python
 from efficient_apriori import apriori
-from efficient_apriori.itemsets import TransactionWithId
-transactions = [
-    TransactionWithId(('eggs', 'bacon', 'soup'), '1'),
-    TransactionWithId(('eggs', 'bacon', 'apple'), '2'),
-    TransactionWithId(('soup', 'bacon', 'banana'), '3'),
-]
-itemsets, rules = apriori(transactions, min_support=0.2,  min_confidence=1)
+transactions = [('eggs', 'bacon', 'soup'),
+                ('eggs', 'bacon', 'apple'),
+                ('soup', 'bacon', 'banana')]
+itemsets, rules = apriori(transactions, output_transaction_ids=True)
 print(itemsets)
-# {1: {('bacon',): ItemsetCount(itemset_count=3, members={'1', '2', '3'}), ...
+# {1: {('bacon',): ItemsetCount(itemset_count=3, members={'0', '1', '2'}), ...
 ```

--- a/efficient_apriori/apriori.py
+++ b/efficient_apriori/apriori.py
@@ -5,19 +5,18 @@ High-level implementations of the apriori algorithm.
 """
 
 import typing
-from efficient_apriori.itemsets import itemsets_from_transactions, \
-    TransactionWithId, ItemsetCount
+from efficient_apriori.itemsets import itemsets_from_transactions, ItemsetCount
 from efficient_apriori.rules import generate_rules_apriori
 
 
 def apriori(
     transactions: typing.Union[typing.List[tuple],
-                               typing.Callable,
-                               typing.List[TransactionWithId]],
+                               typing.Callable],
     min_support: float = 0.5,
     min_confidence: float = 0.5,
     max_length: int = 8,
     verbosity: int = 0,
+    output_transaction_ids: bool = False
 ):
     """
     The classic apriori algorithm as described in 1994 by Agrawal et al.
@@ -51,7 +50,10 @@ def apriori(
         The maximum length of the itemsets and the rules.
     verbosity : int
         The level of detail printing when the algorithm runs. Either 0, 1 or 2.
-    
+    output_transaction_ids : bool
+        If set to true, the output contains the ids of transactions that
+        contain a frequent itemset. The ids are the enumeration of the
+        transactions in the sequence they appear.
     Examples
     --------
     >>> transactions = [('a', 'b', 'c'), ('a', 'b', 'd'), ('f', 'b', 'g')]
@@ -61,7 +63,8 @@ def apriori(
     """
 
     itemsets, num_trans = itemsets_from_transactions(
-        transactions, min_support, max_length, verbosity
+        transactions, min_support, max_length, verbosity,
+        output_transaction_ids
     )
 
     if itemsets and isinstance(next(iter(itemsets[1].values())), ItemsetCount):

--- a/efficient_apriori/apriori.py
+++ b/efficient_apriori/apriori.py
@@ -10,13 +10,12 @@ from efficient_apriori.rules import generate_rules_apriori
 
 
 def apriori(
-    transactions: typing.Union[typing.List[tuple],
-                               typing.Callable],
+    transactions: typing.Union[typing.List[tuple], typing.Callable],
     min_support: float = 0.5,
     min_confidence: float = 0.5,
     max_length: int = 8,
     verbosity: int = 0,
-    output_transaction_ids: bool = False
+    output_transaction_ids: bool = False,
 ):
     """
     The classic apriori algorithm as described in 1994 by Agrawal et al.
@@ -63,8 +62,11 @@ def apriori(
     """
 
     itemsets, num_trans = itemsets_from_transactions(
-        transactions, min_support, max_length, verbosity,
-        output_transaction_ids
+        transactions,
+        min_support,
+        max_length,
+        verbosity,
+        output_transaction_ids,
     )
 
     if itemsets and isinstance(next(iter(itemsets[1].values())), ItemsetCount):

--- a/efficient_apriori/apriori.py
+++ b/efficient_apriori/apriori.py
@@ -54,6 +54,10 @@ def apriori(
     >>> rules
     [{a} -> {b}]
     """
+
+    # TODO: also add warning/error when min_support is < 1
+    # TODO: add warning when very high proportion of transactions remain between iterations
+
     itemsets, num_trans = itemsets_from_transactions(
         transactions, min_support, max_length, verbosity
     )

--- a/efficient_apriori/apriori.py
+++ b/efficient_apriori/apriori.py
@@ -5,12 +5,15 @@ High-level implementations of the apriori algorithm.
 """
 
 import typing
-from efficient_apriori.itemsets import itemsets_from_transactions
+from efficient_apriori.itemsets import itemsets_from_transactions, \
+    TransactionWithId, ItemsetCount
 from efficient_apriori.rules import generate_rules_apriori
 
 
 def apriori(
-    transactions: typing.List[tuple],
+    transactions: typing.Union[typing.List[tuple],
+                               typing.Callable,
+                               typing.List[TransactionWithId]],
     min_support: float = 0.5,
     min_confidence: float = 0.5,
     max_length: int = 8,
@@ -30,7 +33,9 @@ def apriori(
     
     Parameters
     ----------
-    transactions : list of tuples, or a callable returning a generator
+    transactions : list of tuples, list of itemsets.TransactionWithId,
+        or a callable returning a generator. Use TransactionWithId's when
+        the transactions have ids which should appear in the outputs.
         The transactions may be either a list of tuples, where the tuples must
         contain hashable items. Alternatively, a callable returning a generator
         may be passed. A generator is not sufficient, since the algorithm will
@@ -55,16 +60,26 @@ def apriori(
     [{a} -> {b}]
     """
 
-    # TODO: also add warning/error when min_support is < 1
-    # TODO: add warning when very high proportion of transactions remain between iterations
-
     itemsets, num_trans = itemsets_from_transactions(
         transactions, min_support, max_length, verbosity
     )
+
+    if itemsets and isinstance(next(iter(itemsets[1].values())), ItemsetCount):
+        itemsets_for_rules = _convert_to_counts(itemsets)
+    else:
+        itemsets_for_rules = itemsets
+
     rules = generate_rules_apriori(
-        itemsets, min_confidence, num_trans, verbosity
+        itemsets_for_rules, min_confidence, num_trans, verbosity
     )
     return itemsets, list(rules)
+
+
+def _convert_to_counts(itemsets):
+    itemsets_counts = {}
+    for size, sets in itemsets.items():
+        itemsets_counts[size] = {i: c.itemset_count for i, c in sets.items()}
+    return itemsets_counts
 
 
 if __name__ == "__main__":

--- a/efficient_apriori/itemsets.py
+++ b/efficient_apriori/itemsets.py
@@ -261,7 +261,8 @@ def itemsets_from_transactions(
 
     Parameters
     ----------
-    transactions : either a list of itemsets (tuples with hashable entries),
+    transactions : a list of itemsets (tuples with hashable entries),
+                   a list of itemsets.TransactionWithId
                    or a function returning a generator
         A list of transactions. They can be of varying size. To pass through
         data without reading everything into memory at once, a callable

--- a/efficient_apriori/itemsets.py
+++ b/efficient_apriori/itemsets.py
@@ -25,7 +25,6 @@ class ItemsetCount:
 
 
 class _ItemsetCounter(ABC):
-
     @abstractmethod
     def itemset_counter(self):
         pass
@@ -43,13 +42,13 @@ class _ItemsetCounter(ABC):
         pass
 
     @abstractmethod
-    def candidate_itemset_counts(self, C_k, C_k_sets, counter, counts, row,
-                                 transaction):
+    def candidate_itemset_counts(
+        self, C_k, C_k_sets, counter, counts, row, transaction
+    ):
         pass
 
 
 class _Counter(_ItemsetCounter):
-
     def itemset_counter(self):
         return 0
 
@@ -67,12 +66,14 @@ class _Counter(_ItemsetCounter):
 
     def large_itemsets(self, counts, min_support, num_transactions):
         return [
-            (i, c) for (i, c) in counts.items()
+            (i, c)
+            for (i, c) in counts.items()
             if (c / num_transactions) >= min_support
         ]
 
-    def candidate_itemset_counts(self, C_k, C_k_sets, counter, counts, row,
-                                 transaction):
+    def candidate_itemset_counts(
+        self, C_k, C_k_sets, counter, counts, row, transaction
+    ):
         # Assert that no items were found in this row
         found_any = False
         issubset = set.issubset  # Micro-optimization
@@ -86,7 +87,6 @@ class _Counter(_ItemsetCounter):
 
 
 class _CounterWithIds(_ItemsetCounter):
-
     def itemset_counter(self):
         return ItemsetCount()
 
@@ -104,12 +104,14 @@ class _CounterWithIds(_ItemsetCounter):
 
     def large_itemsets(self, counts, min_support, num_transactions):
         return [
-            (i, count) for (i, count) in counts.items()
+            (i, count)
+            for (i, count) in counts.items()
             if (count.itemset_count / num_transactions) >= min_support
         ]
 
-    def candidate_itemset_counts(self, C_k, C_k_sets, counter, counts, row,
-                                 transaction):
+    def candidate_itemset_counts(
+        self, C_k, C_k_sets, counter, counts, row, transaction
+    ):
         # Assert that no items were found in this row
         found_any = False
         issubset = set.issubset  # Micro-optimization
@@ -191,7 +193,7 @@ def join_step(itemsets: typing.List[tuple]):
 
 
 def prune_step(
-        itemsets: typing.Iterable[tuple], possible_itemsets: typing.List[tuple]
+    itemsets: typing.Iterable[tuple], possible_itemsets: typing.List[tuple]
 ):
     """
     Prune possible itemsets whose subsets are not in the list of itemsets.
@@ -224,7 +226,7 @@ def prune_step(
         # due to the way the `join_step` function merges the sorted itemsets
 
         for i in range(len(possible_itemset) - 2):
-            removed = possible_itemset[:i] + possible_itemset[i + 1:]
+            removed = possible_itemset[:i] + possible_itemset[i + 1 :]
 
             # If every k combination exists in the set of itemsets,
             # yield the possible itemset. If it does not exist, then it's
@@ -266,12 +268,11 @@ def apriori_gen(itemsets: typing.List[tuple]):
 
 
 def itemsets_from_transactions(
-        transactions: typing.Union[typing.List[tuple],
-                                   typing.Callable],
-        min_support: float,
-        max_length: int = 8,
-        verbosity: int = 0,
-        output_transaction_ids: bool = False
+    transactions: typing.Union[typing.List[tuple], typing.Callable],
+    min_support: float,
+    max_length: int = 8,
+    verbosity: int = 0,
+    output_transaction_ids: bool = False,
 ):
     """
     Compute itemsets from transactions by building the itemsets bottom up and
@@ -316,7 +317,7 @@ def itemsets_from_transactions(
     # STEP 0 - Sanitize user inputs
     # -----------------------------
     if not (
-            isinstance(min_support, numbers.Number) and (0 <= min_support <= 1)
+        isinstance(min_support, numbers.Number) and (0 <= min_support <= 1)
     ):
         raise ValueError("`min_support` must be a number between 0 and 1.")
 
@@ -325,23 +326,29 @@ def itemsets_from_transactions(
     else:
         counter = _Counter()
 
-    wrong_transaction_type_msg = "`transactions` must be an iterable or a " \
-                                 "callable returning an iterable."
+    wrong_transaction_type_msg = (
+        "`transactions` must be an iterable or a "
+        "callable returning an iterable."
+    )
     if not transactions:
         return empty_result(0)
     elif isinstance(transactions, collections.Iterable):
+
         def transaction_rows():
             count = 0
             for t in transactions:
                 yield count, set(t)
                 count += 1
+
     # Assume the transactions is a callable, returning a generator
     elif callable(transactions):
+
         def transaction_rows():
             count = 0
             for t in transactions():
                 yield count, set(t)
                 count += 1
+
         generator = transactions()
         if not isinstance(generator, collections.abc.Generator):
             raise TypeError(wrong_transaction_type_msg)
@@ -360,8 +367,9 @@ def itemsets_from_transactions(
 
     counts, num_transactions = counter.singleton_itemsets(transaction_rows)
 
-    large_itemsets = counter.large_itemsets(counts, min_support,
-                                            num_transactions)
+    large_itemsets = counter.large_itemsets(
+        counts, min_support, num_transactions
+    )
 
     if verbosity > 0:
         num_cand, num_itemsets = len(counts.items()), len(large_itemsets)
@@ -372,8 +380,9 @@ def itemsets_from_transactions(
 
     # If large itemsets were found, convert to dictionary
     if large_itemsets:
-        large_itemsets = {1: {(i,): counts for (i, counts) in
-                              sorted(large_itemsets)}}
+        large_itemsets = {
+            1: {(i,): counts for (i, counts) in sorted(large_itemsets)}
+        }
     # No large itemsets were found, return immediately
     else:
         return empty_result(num_transactions)
@@ -420,7 +429,8 @@ def itemsets_from_transactions(
                 continue
 
             counts, found_any = counter.candidate_itemset_counts(
-                C_k, C_k_sets, counter, counts, row, transaction)
+                C_k, C_k_sets, counter, counts, row, transaction
+            )
 
             # If no candidate sets were found in this row, skip this row of
             # transactions in the future

--- a/efficient_apriori/itemsets.py
+++ b/efficient_apriori/itemsets.py
@@ -11,14 +11,13 @@ import typing
 from abc import ABC, abstractmethod
 
 from collections import defaultdict
-
-from attr import dataclass
+from dataclasses import field, dataclass
 
 
 @dataclass
 class ItemsetCount:
     itemset_count: int = 0
-    members: set = set()
+    members: set = field(default_factory=set)
 
 
 class TransactionWithId:

--- a/efficient_apriori/rules.py
+++ b/efficient_apriori/rules.py
@@ -7,7 +7,7 @@ Implementations of algorithms related to association rules.
 import typing
 import numbers
 import itertools
-from efficient_apriori.itemsets import apriori_gen
+from efficient_apriori.itemsets import apriori_gen, ItemsetCount
 
 
 class Rule(object):
@@ -104,7 +104,7 @@ class Rule(object):
         try:
             observed_support = self.count_full / self.num_transactions
             prod_counts = self.count_lhs * self.count_rhs
-            expected_support = (prod_counts) / self.num_transactions ** 2
+            expected_support = prod_counts / self.num_transactions ** 2
             return observed_support / expected_support
         except ZeroDivisionError:
             return None
@@ -280,7 +280,7 @@ def _genrules(l_k, a_m, itemsets, min_conf, num_transactions):
 
 
 def generate_rules_apriori(
-    itemsets: typing.Dict[int, typing.Dict[tuple, int]],
+    itemsets: typing.Dict[int, typing.Dict[tuple, ItemsetCount]],
     min_confidence: float,
     num_transactions: int,
     verbosity: int = 0,
@@ -332,7 +332,7 @@ def generate_rules_apriori(
         """
         Helper function to retrieve the count of the itemset in the dataset.
         """
-        return itemsets[len(itemset)][itemset]
+        return itemsets[len(itemset)][itemset].itemset_count
 
     if verbosity > 0:
         print("Generating rules from itemsets.")
@@ -383,7 +383,7 @@ def generate_rules_apriori(
 def _ap_genrules(
     itemset: tuple,
     H_m: typing.List[tuple],
-    itemsets: typing.Dict[int, typing.Dict[tuple, int]],
+    itemsets: typing.Dict[int, typing.Dict[tuple, ItemsetCount]],
     min_conf: float,
     num_transactions: int,
 ):
@@ -411,7 +411,7 @@ def _ap_genrules(
         """
         Helper function to retrieve the count of the itemset in the dataset.
         """
-        return itemsets[len(itemset)][itemset]
+        return itemsets[len(itemset)][itemset].itemset_count
 
     # If H_1 is so large that calling `apriori_gen` will produce right-hand
     # sides as large as `itemset`, there will be no right hand side

--- a/efficient_apriori/rules.py
+++ b/efficient_apriori/rules.py
@@ -7,7 +7,7 @@ Implementations of algorithms related to association rules.
 import typing
 import numbers
 import itertools
-from efficient_apriori.itemsets import apriori_gen, ItemsetCount
+from efficient_apriori.itemsets import apriori_gen
 
 
 class Rule(object):
@@ -280,7 +280,7 @@ def _genrules(l_k, a_m, itemsets, min_conf, num_transactions):
 
 
 def generate_rules_apriori(
-    itemsets: typing.Dict[int, typing.Dict[tuple, ItemsetCount]],
+    itemsets: typing.Dict[int, typing.Dict[tuple, int]],
     min_confidence: float,
     num_transactions: int,
     verbosity: int = 0,
@@ -332,7 +332,7 @@ def generate_rules_apriori(
         """
         Helper function to retrieve the count of the itemset in the dataset.
         """
-        return itemsets[len(itemset)][itemset].itemset_count
+        return itemsets[len(itemset)][itemset]
 
     if verbosity > 0:
         print("Generating rules from itemsets.")
@@ -383,7 +383,7 @@ def generate_rules_apriori(
 def _ap_genrules(
     itemset: tuple,
     H_m: typing.List[tuple],
-    itemsets: typing.Dict[int, typing.Dict[tuple, ItemsetCount]],
+    itemsets: typing.Dict[int, typing.Dict[tuple, int]],
     min_conf: float,
     num_transactions: int,
 ):
@@ -411,7 +411,7 @@ def _ap_genrules(
         """
         Helper function to retrieve the count of the itemset in the dataset.
         """
-        return itemsets[len(itemset)][itemset].itemset_count
+        return itemsets[len(itemset)][itemset]
 
     # If H_1 is so large that calling `apriori_gen` will produce right-hand
     # sides as large as `itemset`, there will be no right hand side

--- a/efficient_apriori/tests/test_itemsets_with_ids.py
+++ b/efficient_apriori/tests/test_itemsets_with_ids.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Tests for algorithms related to association rules.
+"""
+
+import os
+import pytest
+import itertools
+import random
+
+from efficient_apriori.itemsets import itemsets_from_transactions, \
+    TransactionWithId, ItemsetCount
+
+
+def generate_transactions(
+    num_transactions, unique_items, items_row=(1, 100), seed=None
+):
+    """
+    Generate synthetic transactions.
+    """
+    if seed:
+        random.seed(seed)
+    else:
+        random.seed()
+
+    items = list(range(unique_items))
+
+    for transaction_num in range(num_transactions):
+        items_this_row = random.randint(*items_row)
+        t = random.sample(items, k=min(unique_items, items_this_row))
+        yield TransactionWithId(t, str(transaction_num))
+
+
+def itemsets_from_transactions_naive(transactions, min_support):
+    """
+    Naive algorithm used for testing only.
+    """
+
+    # Get the unique items from every transaction
+    unique_items = {k for t in transactions for k in t.transaction}
+    num_transactions = len(transactions)
+
+    # Create an output dictionary
+    L = dict()
+
+    # For every possible combination length
+    for k in range(1, len(unique_items) + 1):
+
+        # For every possible combination
+        for combination in itertools.combinations(unique_items, k):
+
+            # Naively count how many transactions contain the combination
+            counts = ItemsetCount()
+            for t in transactions:
+                if set.issubset(set(combination), set(t.transaction)):
+                    counts.itemset_count += 1
+                    counts.members.add(t.id)
+
+            # If the count exceeds the minimum support, add it
+            if (counts.itemset_count / num_transactions) >= min_support:
+                try:
+                    L[k][tuple(sorted(list(combination)))] = counts
+                except KeyError:
+                    L[k] = dict()
+                    L[k][tuple(sorted(list(combination)))] = counts
+
+        try:
+            L[k] = {k: v for (k, v) in sorted(L[k].items())}
+            if L[k] == {}:
+                del L[k]
+                return L, num_transactions
+        except KeyError:
+            return L, num_transactions
+
+    return L, num_transactions
+
+
+input_data = [
+    (
+        list(
+            generate_transactions(
+                random.randint(5, 25),
+                random.randint(1, 8),
+                (1, random.randint(2, 8)),
+            )
+        ),
+        random.randint(1, 4) / 10,
+    )
+    for i in range(10)
+]
+
+
+@pytest.mark.parametrize("transactions, min_support", input_data)
+def test_itemsets_from_transactions_stochastic(transactions, min_support):
+    """
+    Test 50 random inputs.
+    """
+    result, _ = itemsets_from_transactions(list(transactions), min_support)
+    naive_result, _ = itemsets_from_transactions_naive(
+        list(transactions), min_support
+    )
+
+    for key in set.union(set(result.keys()), set(naive_result.keys())):
+        assert result[key] == naive_result[key]
+
+
+@pytest.mark.parametrize("transactions, min_support", input_data)
+def test_itemsets_max_length(transactions, min_support):
+    """
+    The that nothing larger than max length is returned.
+    """
+    max_len = random.randint(1, 5)
+    result, _ = itemsets_from_transactions(
+        list(transactions), min_support, max_length=max_len
+    )
+
+    assert all(list(k <= max_len for k in result.keys()))
+
+
+def test_itemsets_from_a_generator_callable():
+    """
+    Test generator feature.
+    """
+
+    def generator():
+        """
+        A generator for testing.
+        """
+        for i in range(4):
+            yield TransactionWithId(tuple(j + i for j in range(5)), i)
+
+    itemsets, _ = itemsets_from_transactions(generator, min_support=3 / 4)
+    assert itemsets[3] == {
+        (2, 3, 4): ItemsetCount(itemset_count=3, members={0, 1, 2, 3}),
+        (3, 4, 5): ItemsetCount(itemset_count=3, members={0, 1, 2, 3})
+    }
+
+
+def test_itemsets_from_a_file():
+    """
+    Test generator feature.
+    """
+
+    def file_generator(filename):
+        """
+        A file generator for testing.
+        """
+
+        def generate_from_file():
+            with open(filename) as file:
+                for line in file:
+                    yield tuple(line.strip("\n").split(","))
+
+        return generate_from_file
+
+    base, filename = os.path.split(__file__)
+    gen_obj = file_generator(os.path.join(base, "transactions.txt"))
+    result, _ = itemsets_from_transactions(gen_obj, min_support=4 / 4)
+    assert result[2] == {("A", "C"): 4}
+
+
+if __name__ == "__main__":
+    pytest.main(args=[".", "--doctest-modules", "-v"])

--- a/efficient_apriori/tests/test_itemsets_with_ids.py
+++ b/efficient_apriori/tests/test_itemsets_with_ids.py
@@ -128,12 +128,13 @@ def test_itemsets_from_a_generator_callable():
         A generator for testing.
         """
         for i in range(4):
-            yield TransactionWithId(tuple(j + i for j in range(5)), i)
+            transactions = tuple(j + i for j in range(5))
+            yield TransactionWithId(transactions, i)
 
     itemsets, _ = itemsets_from_transactions(generator, min_support=3 / 4)
     assert itemsets[3] == {
-        (2, 3, 4): ItemsetCount(itemset_count=3, members={0, 1, 2, 3}),
-        (3, 4, 5): ItemsetCount(itemset_count=3, members={0, 1, 2, 3})
+        (2, 3, 4): ItemsetCount(itemset_count=3, members={0, 1, 2}),
+        (3, 4, 5): ItemsetCount(itemset_count=3, members={1, 2, 3})
     }
 
 
@@ -142,13 +143,13 @@ def test_itemsets_from_a_file():
     Test generator feature.
     """
 
-    def file_generator(filename):
+    def file_generator(filename_):
         """
         A file generator for testing.
         """
 
         def generate_from_file():
-            with open(filename) as file:
+            with open(filename_) as file:
                 for i, line in enumerate(file):
                     transactions = tuple(line.strip("\n").split(","))
                     yield TransactionWithId(transactions, i)

--- a/efficient_apriori/tests/test_itemsets_with_ids.py
+++ b/efficient_apriori/tests/test_itemsets_with_ids.py
@@ -149,15 +149,18 @@ def test_itemsets_from_a_file():
 
         def generate_from_file():
             with open(filename) as file:
-                for line in file:
-                    yield tuple(line.strip("\n").split(","))
+                for i, line in enumerate(file):
+                    transactions = tuple(line.strip("\n").split(","))
+                    yield TransactionWithId(transactions, i)
 
         return generate_from_file
 
     base, filename = os.path.split(__file__)
     gen_obj = file_generator(os.path.join(base, "transactions.txt"))
     result, _ = itemsets_from_transactions(gen_obj, min_support=4 / 4)
-    assert result[2] == {("A", "C"): 4}
+    assert result[2] == {
+        ("A", "C"): ItemsetCount(itemset_count=4, members={0, 1, 2, 3})
+    }
 
 
 if __name__ == "__main__":

--- a/efficient_apriori/tests/test_itemsets_with_ids.py
+++ b/efficient_apriori/tests/test_itemsets_with_ids.py
@@ -94,8 +94,9 @@ def test_itemsets_from_transactions_stochastic(transactions, min_support):
     """
     Test 50 random inputs.
     """
-    result, _ = itemsets_from_transactions(list(transactions), min_support,
-                                           output_transaction_ids=True)
+    result, _ = itemsets_from_transactions(
+        list(transactions), min_support, output_transaction_ids=True
+    )
     naive_result, _ = itemsets_from_transactions_naive(
         list(transactions), min_support
     )
@@ -111,8 +112,10 @@ def test_itemsets_max_length(transactions, min_support):
     """
     max_len = random.randint(1, 5)
     result, _ = itemsets_from_transactions(
-        list(transactions), min_support, max_length=max_len,
-        output_transaction_ids=True
+        list(transactions),
+        min_support,
+        max_length=max_len,
+        output_transaction_ids=True,
     )
 
     assert all(list(k <= max_len for k in result.keys()))
@@ -131,11 +134,12 @@ def test_itemsets_from_a_generator_callable():
             transactions = tuple(j + i for j in range(5))
             yield transactions
 
-    itemsets, _ = itemsets_from_transactions(generator, min_support=3 / 4,
-                                             output_transaction_ids=True)
+    itemsets, _ = itemsets_from_transactions(
+        generator, min_support=3 / 4, output_transaction_ids=True
+    )
     assert itemsets[3] == {
         (2, 3, 4): ItemsetCount(itemset_count=3, members={0, 1, 2}),
-        (3, 4, 5): ItemsetCount(itemset_count=3, members={1, 2, 3})
+        (3, 4, 5): ItemsetCount(itemset_count=3, members={1, 2, 3}),
     }
 
 
@@ -159,8 +163,9 @@ def test_itemsets_from_a_file():
 
     base, filename = os.path.split(__file__)
     gen_obj = file_generator(os.path.join(base, "transactions.txt"))
-    result, _ = itemsets_from_transactions(gen_obj, min_support=4 / 4,
-                                           output_transaction_ids=True)
+    result, _ = itemsets_from_transactions(
+        gen_obj, min_support=4 / 4, output_transaction_ids=True
+    )
     assert result[2] == {
         ("A", "C"): ItemsetCount(itemset_count=4, members={0, 1, 2, 3})
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytest>=3.6.1
 numpydoc>=0.8.0
+dataclasses==0.6


### PR DESCRIPTION
This allows the client to pass through transactions with IDs, signalling that the algorithm should keep track of _where_ the frequent itemsets occur. 
The results then contain itemsets with their counts as well as the IDs of transactions where they occurred.

The main conceptual changes were in itemsets.py:

1. TransactionBroker - handles fetching rows of transactions for all the different types of input.
2. CountBroker - handles counting for all transaction input types. For transactions with ids, the count method also keeps track of the transaction ID. The idea here was to keep the core of the algorithm code semantically the same.

The new test file might look a bit familiar since it's copied from test_itemsets.py but with changes to cover all the ways IDs can be passed in.

The original code was a joy to work with - hopefully I haven't changed that too much :)