### PR TITLE
Reducing H_1

### DIFF
--- a/efficient_apriori/rules.py
+++ b/efficient_apriori/rules.py
@@ -335,9 +335,12 @@ def generate_rules_apriori(
 
         # For every itemset of this size
         for itemset in itemsets[size].keys():
+            # Generate combinations to start off of. These 1-combinations will
+            # be merged to 2-combinations in the function `_ap_genrules`
+            H_1 = list(itertools.combinations(itemset, 1))
 
             # Special case to capture rules such as {others} -> {1 item}
-            for removed in itertools.combinations(itemset, 1):
+            for removed in H_1:
 
                 # Compute the left hand side
                 remaining = set(itemset).difference(set(removed))
@@ -354,10 +357,11 @@ def generate_rules_apriori(
                         count(removed),
                         num_transactions,
                     )
+                # otherwise, remove the 1-item rhs from H_1, since no larger rhs with that item in it will have high
+                # enough confidence.
+                else:
+                    H_1.remove(removed)
 
-            # Generate combinations to start off of. These 1-combinations will
-            # be merged to 2-combinations in the function `_ap_genrules`
-            H_1 = list(itertools.combinations(itemset, 1))
             yield from _ap_genrules(itemset, H_1, itemsets, min_confidence, num_transactions)
 
     if verbosity > 0:


### PR DESCRIPTION
The docstring of `generate_rules_apriori` says: 

>     The algorithm is based on the observation that for {a, b} -> {c, d} to
>     hold, both {a, b, c} -> {d} and {a, b, d} -> {c} must hold, since in
>     general conf( {a, b, c} -> {d} ) >= conf( {a, b} -> {c, d} ).
>     In other words, if either of the two one-consequent rules do not hold, then
>     there is no need to ever consider the two-consequent rule.

But in H_1, items are never removed if they produced a low confidence rule. This has been fixed.

NOTE: One test fails and I did not have the time to investigate exactly why:
`test_generate_rules_apriori_large`:
`Expected :5387`
`Actual   :5382`

This must be cleared before accepting the request