### PR TITLE
Reducing H_1 (#45)

### DIFF
--- a/efficient_apriori/rules.py
+++ b/efficient_apriori/rules.py
@@ -335,7 +335,10 @@ def generate_rules_apriori(
 
         # For every itemset of this size
         for itemset in itemsets[size].keys():
-
+            
+            # Generate combinations to start off of. These 1-combinations will
+            # be merged to 2-combinations in the function `_ap_genrules`
+            H_1 = []
             # Special case to capture rules such as {others} -> {1 item}
             for removed in itertools.combinations(itemset, 1):
 
@@ -354,10 +357,10 @@ def generate_rules_apriori(
                         count(removed),
                         num_transactions,
                     )
+                    
+                    # Consider the removed item for 2-combinations in the function `_ap_genrules`
+                    H_1.append(removed)
 
-            # Generate combinations to start off of. These 1-combinations will
-            # be merged to 2-combinations in the function `_ap_genrules`
-            H_1 = list(itertools.combinations(itemset, 1))
             yield from _ap_genrules(itemset, H_1, itemsets, min_confidence, num_transactions)
 
     if verbosity > 0:

--- a/efficient_apriori/rules.py
+++ b/efficient_apriori/rules.py
@@ -335,7 +335,7 @@ def generate_rules_apriori(
 
         # For every itemset of this size
         for itemset in itemsets[size].keys():
-            
+
             # Generate combinations to start off of. These 1-combinations will
             # be merged to 2-combinations in the function `_ap_genrules`
             H_1 = []
@@ -357,7 +357,7 @@ def generate_rules_apriori(
                         count(removed),
                         num_transactions,
                     )
-                    
+
                     # Consider the removed item for 2-combinations in the function `_ap_genrules`
                     H_1.append(removed)
 


### PR DESCRIPTION
Hi. I gave it a try in response to #45. Specifically, instead of [propagating all items of each itemset]( https://github.com/tommyod/Efficient-Apriori/blob/01d174379c51758aa2f6d2926b473124928dc631/efficient_apriori/rules.py#L360) to the [`_ap_genrules`](https://github.com/hprshayan/Efficient-Apriori/blob/184fecbdb5fb1cfe7bb1cb97b8b860262c6aba2f/efficient_apriori/rules.py#L370)  function, I only [include the items that have confidence > min_confidence](https://github.com/hprshayan/Efficient-Apriori/blob/184fecbdb5fb1cfe7bb1cb97b8b860262c6aba2f/efficient_apriori/rules.py#L362) in `H_1`.