### PR TITLE
Fixing H_1 reduction update in #53 (mentioned in #57)

### DIFF
--- a/efficient_apriori/itemsets.py
+++ b/efficient_apriori/itemsets.py
@@ -23,7 +23,6 @@ class TransactionManager:
     # https://github.com/ymoch/apyori/blob/master/apyori.py
 
     def __init__(self, transactions: typing.Iterable[typing.Iterable[typing.Hashable]]):
-
         # A lookup that returns indices of transactions for each item
         self.indices_by_item = collections.defaultdict(set)
 
@@ -110,7 +109,6 @@ def join_step(itemsets: typing.List[tuple]):
     i = 0
     # Iterate over every itemset in the itemsets
     while i < len(itemsets):
-
         # The number of rows to skip in the while-loop, initially set to 1
         skip = 1
 
@@ -128,13 +126,11 @@ def join_step(itemsets: typing.List[tuple]):
 
         # Iterate over ever itemset following this itemset
         for j in range(i + 1, len(itemsets)):
-
             # Get all but the last item in the itemset, and the last item
             *itemset_n_first, itemset_n_last = itemsets[j]
 
             # If it's the same, append and skip this itemset in while-loop
             if itemset_first == itemset_n_first:
-
                 # Micro-optimization
                 tail_items_append(itemset_n_last)
                 skip += 1
@@ -178,7 +174,6 @@ def prune_step(itemsets: typing.Iterable[tuple], possible_itemsets: typing.List[
 
     # Go through every possible itemset
     for possible_itemset in possible_itemsets:
-
         # Remove 1 from the combination, same as k-1 combinations
         # The itemsets created by removing the last two items in the possible
         # itemsets must be part of the itemsets by definition,
@@ -375,7 +370,6 @@ def itemsets_from_transactions(
 
 
 if __name__ == "__main__":
-
     import pytest
 
     pytest.main(args=[".", "--doctest-modules", "-v"])

--- a/efficient_apriori/rules.py
+++ b/efficient_apriori/rules.py
@@ -201,7 +201,6 @@ def generate_rules_simple(
 
     # Iterate over every size
     for size in itemsets.keys():
-
         # Do not consider itemsets of size 1
         if size < 2:
             continue
@@ -213,10 +212,8 @@ def generate_rules_simple(
 
         # Iterate over every itemset of the prescribed size
         for itemset in itemsets[size].keys():
-
             # Generate rules
             for result in _genrules(itemset, itemset, itemsets, min_confidence, num_transactions):
-
                 # If the rule has been yieded, keep going, else add and yield
                 if result in yielded:
                     continue
@@ -250,7 +247,6 @@ def _genrules(l_k, a_m, itemsets, min_conf, num_transactions):
     # Iterate over every k - 1 combination of a_m to produce
     # rules of the form a -> (l - a)
     for a_m in itertools.combinations(a_m, len(a_m) - 1):
-
         # Compute the count of this rule, which is a_m -> (l_k - a_m)
         confidence = count(l_k) / count(a_m)
 
@@ -325,7 +321,6 @@ def generate_rules_apriori(
 
     # For every itemset of a perscribed size
     for size in itemsets.keys():
-
         # Do not consider itemsets of size 1
         if size < 2:
             continue
@@ -335,13 +330,11 @@ def generate_rules_apriori(
 
         # For every itemset of this size
         for itemset in itemsets[size].keys():
-
             # Generate combinations to start off of. These 1-combinations will
             # be merged to 2-combinations in the function `_ap_genrules`
             H_1 = []
             # Special case to capture rules such as {others} -> {1 item}
             for removed in itertools.combinations(itemset, 1):
-
                 # Compute the left hand side
                 remaining = set(itemset).difference(set(removed))
                 lhs = tuple(sorted(remaining))
@@ -416,7 +409,6 @@ def _ap_genrules(
 
     # For every possible right hand side
     for h_m in H_m:
-
         # Compute the left hand side of the rule
         lhs = tuple(sorted(set(itemset).difference(set(h_m))))
 

--- a/efficient_apriori/rules.py
+++ b/efficient_apriori/rules.py
@@ -361,6 +361,10 @@ def generate_rules_apriori(
                     # Consider the removed item for 2-combinations in the function `_ap_genrules`
                     H_1.append(removed)
 
+            # If H_1 is empty, there is nothing for passing to _ap_genrules, so continue to the next itemset
+            if len(H_1) == 0:
+                continue
+
             yield from _ap_genrules(itemset, H_1, itemsets, min_confidence, num_transactions)
 
     if verbosity > 0:

--- a/efficient_apriori/tests/test_apriori.py
+++ b/efficient_apriori/tests/test_apriori.py
@@ -11,7 +11,6 @@ from efficient_apriori.itemsets import ItemsetCount
 
 
 def test_api():
-
     transactions = [
         ("a", "c", "e"),
         ("a", "c", "e"),
@@ -30,7 +29,6 @@ def test_api():
     for count, itemsets_dict in itemsets.items():
         assert isinstance(itemsets_dict, dict)
         for itemset, count in itemsets_dict.items():
-
             actual_count = sum(1 if set(itemset).issubset(set(trans)) else 0 for trans in transactions)
             assert count == actual_count
 
@@ -246,6 +244,29 @@ def test_iterator_input():
     assert len(rules1) == len(rules2)
     for i in range(len(rules1)):
         assert rules1[i] == rules2[i]
+
+
+def test_empty_H_1():
+    """
+    An example of the case where there are itemsets without any Rule with
+    single item in right hand side that satifies the required minimum confidence.
+    The issue is raised in #57.
+    """
+    # The results are received from commit
+    true_itemsets_raw = {1: {(1,): 4, (2,): 5, (3,): 4}, 2: {(1, 2): 4, (1, 3): 3, (2, 3): 4}, 3: {(1, 2, 3): 3}}
+    true_rules = [
+        Rule((2,), (1,), 4, 5, 4, 5),
+        Rule((1,), (2,), 4, 4, 5, 5),
+        Rule((3,), (2,), 4, 4, 5, 5),
+        Rule((2,), (3,), 4, 5, 4, 5),
+        Rule((1, 3), (2,), 3, 3, 5, 5),
+    ]
+
+    transactions = [(1, 2, 3), (1, 2, 3), (1, 2, 3), (1, 2), (2, 3)]
+    itemsets_raw, rules = apriori(transactions, 0.4, 0.8)
+
+    assert itemsets_raw == true_itemsets_raw
+    assert all(rule == true_rule for rule, true_rule in zip(rules, true_rules))
 
 
 if __name__ == "__main__":

--- a/efficient_apriori/tests/test_apriori.py
+++ b/efficient_apriori/tests/test_apriori.py
@@ -252,7 +252,7 @@ def test_empty_H_1():
     single item in right hand side that satifies the required minimum confidence.
     The issue is raised in #57.
     """
-    # The results are received from commit
+    # The results are received from commit 01d174379c51758aa2f6d2926b473124928dc631
     true_itemsets_raw = {1: {(1,): 4, (2,): 5, (3,): 4}, 2: {(1, 2): 4, (1, 3): 3, (2, 3): 4}, 3: {(1, 2, 3): 3}}
     true_rules = [
         Rule((2,), (1,), 4, 5, 4, 5),

--- a/efficient_apriori/tests/test_itemsets.py
+++ b/efficient_apriori/tests/test_itemsets.py
@@ -41,10 +41,8 @@ def itemsets_from_transactions_naive(transactions, min_support):
 
     # For every possible combination length
     for k in range(1, len(unique_items) + 1):
-
         # For every possible combination
         for combination in itertools.combinations(unique_items, k):
-
             # Naively count how many transactions contain the combination
             counts = 0
             for transaction in transactions:

--- a/efficient_apriori/tests/test_itemsets_with_ids.py
+++ b/efficient_apriori/tests/test_itemsets_with_ids.py
@@ -41,10 +41,8 @@ def itemsets_from_transactions_naive(transactions, min_support):
 
     # For every possible combination length
     for k in range(1, len(unique_items) + 1):
-
         # For every possible combination
         for combination in itertools.combinations(unique_items, k):
-
             # Naively count how many transactions contain the combination
             counts = ItemsetCount()
             for i, t in enumerate(transactions):


### PR DESCRIPTION
As mentioned in #57, the H_1 reduction update breaks in the following example:
```python
from efficient_apriori.apriori import apriori
transactions = [(1, 2, 3), (1, 2, 3), (1, 2, 3), (1, 2), (2, 3)]
apriori(transactions, 0.4, 0.8)
```
In this PR, the bug is resolved; the result of the above example complies with the version before #53 (https://github.com/tommyod/Efficient-Apriori/commit/01d174379c51758aa2f6d2926b473124928dc631).